### PR TITLE
Add randomness to mcts and nnet evaluation

### DIFF
--- a/mcts.py
+++ b/mcts.py
@@ -32,7 +32,8 @@ class MCTS:
                 return visit_counts / np.sum(visit_counts)
             else:
                 # Fallback if all visit counts are zero (shouldn't happen normally)
-                return np.ones_like(visit_counts) / len(visit_counts)
+                valid_moves = game.get_valid_moves()
+                return valid_moves / np.sum(valid_moves)
 
     # Returns the best move in the given game
     def choose_best_move(self, game, temperature=0, num_iterations=NUM_ITERATIONS):

--- a/mcts.py
+++ b/mcts.py
@@ -6,6 +6,7 @@ from breakthrough import TOTAL_MOVES
 NUM_ITERATIONS = 1000 # Default number of MCTS simulations per move
 C_BASE = 19652 # Determines how quickly exploration bonus decreases as visits accumulate
 C_INIT = 1.25 # Initial exploration weight before visits accumulate
+
 class MCTS:
     def __init__(self, nnet, c_base = C_BASE, c_init = C_INIT):
         self.nnet = nnet
@@ -15,16 +16,28 @@ class MCTS:
         self.nn_cache = {}
 
     # Returns a vector describing the probabilities of choosing each move in the given game
-    def compute_policy(self, game, num_iterations = NUM_ITERATIONS):
+    def compute_policy(self, game, temperature=1.0, num_iterations=NUM_ITERATIONS):
         self.simulate(game, num_iterations)
         visit_counts = self.root.child_N
-        return visit_counts / np.sum(visit_counts)
+        
+        # Deterministic policy (choose best move)
+        if temperature == 0:
+            best_moves = np.argwhere(visit_counts == np.max(visit_counts)).flatten()
+            policy = np.zeros_like(visit_counts)
+            policy[np.random.choice(best_moves)] = 1.0
+            return policy
+        else:
+            visit_counts = visit_counts ** (1. / temperature)
+            if np.sum(visit_counts) > 0:
+                return visit_counts / np.sum(visit_counts)
+            else:
+                # Fallback if all visit counts are zero (shouldn't happen normally)
+                return np.ones_like(visit_counts) / len(visit_counts)
 
     # Returns the best move in the given game
-    def choose_best_move(self, game, num_iterations = NUM_ITERATIONS):
-        self.simulate(game, num_iterations)
-        visit_counts = self.root.child_N
-        return np.argmax(visit_counts)
+    def choose_best_move(self, game, temperature=0, num_iterations=NUM_ITERATIONS):
+        policy = self.compute_policy(game, temperature, num_iterations)
+        return np.random.choice(len(policy), p=policy)
 
     # Runs MCTS for the given number of iterations
     def simulate(self, game, num_iterations):
@@ -64,7 +77,6 @@ class MCTS:
         result = self.nnet.predict(game_state)
         self.nn_cache[game_state_key] = result
         return result
-
 
 # To maintain that every MCTSNode has a parent
 class DummyNode:
@@ -124,7 +136,6 @@ class MCTSNode:
         scores[~valid_moves] = -np.inf # eliminates illegal moves
         best_move = np.argmax(scores) # breakthrough should always have a valid move
         return best_move
-
 
     # Expands the current node (just fills up prior probabilities)
     def expand(self, child_P):


### PR DESCRIPTION
### Changes Made

1. **Modified `compute_policy` method**:
   - Added temperature parameter with default value of 1.0
   - Implemented temperature-based move selection logic:
     - For temperature=0: Deterministic selection (one-hot vector)
     - For temperature>0: Stochastic selection based on visit counts raised to power of 1/temperature

2. **Updated `choose_best_move` method**:
   - Added temperature parameter with default value of 0
   - Now uses `compute_policy` with the specified temperature
   - Returns a move sampled from the resulting probability distribution

3. **Modified `is_new_nnet_better` method**:
   - Added small non-zero temperature (0.2) for evaluation games

I referenced the [write up](https://github.com/suragnair/alpha-zero-general/raw/master/pretrained_models/writeup.pdf) of the othello blog for this change, however, in our case, I set the temperature to 0.2 during evaluation so it adds a little bit of randomness:

> In our experiments, the temperature parameter τ is set to 1 for the first 25 turns in an episode, to encourage early exploration, and then set to 0. It is always set to 0 during evaluation. 