### PR TITLE
Add play_move to mcts, reuse mcts across games in the same epoch

### DIFF
--- a/arena.py
+++ b/arena.py
@@ -2,11 +2,13 @@ class Arena:
     def __init__(self, game_cls):
         self.game_cls = game_cls
 
-    def play(self, player1, player2):
+    def play(self, mcts_player1, mcts_player2, temp):
         game = self.game_cls()
         is_player1_turn = True
         while not game.is_game_over():
-            move = player1(game) if is_player1_turn else player2(game)
+            move = mcts_player1.choose_best_move(game, temp) if is_player1_turn else mcts_player2.choose_best_move(game, temp)
             game.play_move(move)
+            mcts_player1.play_move(move)
+            mcts_player2.play_move(move)
             is_player1_turn = not is_player1_turn
         return game.get_result()

--- a/trainer.py
+++ b/trainer.py
@@ -48,10 +48,8 @@ class Trainer:
             logger.info('Running self-play games')
             mcts = MCTS(self.nnet)
             for _ in trange(NUM_EPISODES):
-                logger.info('Starting self-play game...')
                 mcts.reset_tree()
                 self.self_play_game(self.training_data_buffer, mcts)
-                logger.info('Finishing self-play game...')
             logger.info('Self-play games completed')
 
             logger.info('Training neural network')

--- a/trainer.py
+++ b/trainer.py
@@ -100,15 +100,12 @@ class Trainer:
         
         eval_temperature = 0.2
         
-        curr_player = lambda game: curr_mcts.choose_best_move(game, temperature=eval_temperature)
-        new_player = lambda game: new_mcts.choose_best_move(game, temperature=eval_temperature)
-        
         new_player_wins = 0
         for i in trange(NUM_EVALUATION_GAMES):
             if i % 2 == 0:
-                new_player_wins += self.arena.play(new_player, curr_player) == 1
+                new_player_wins += self.arena.play(new_mcts, curr_mcts, eval_temperature) == 1
             else:
-                new_player_wins += self.arena.play(curr_player, new_player) == -1
+                new_player_wins += self.arena.play(curr_mcts, new_mcts, eval_temperature) == -1
         
         win_rate = new_player_wins / NUM_EVALUATION_GAMES
         logger.info(f'Evaluation games completed, win rate: {win_rate}')

--- a/trainer.py
+++ b/trainer.py
@@ -46,8 +46,12 @@ class Trainer:
         for epoch in range(self.start_epoch, max_epochs + 1):
             logger.info(f'Starting epoch {epoch}/{max_epochs}')
             logger.info('Running self-play games')
+            mcts = MCTS(self.nnet)
             for _ in trange(NUM_EPISODES):
-                self.self_play_game(self.training_data_buffer, self.nnet)
+                logger.info('Starting self-play game...')
+                mcts.reset_tree()
+                self.self_play_game(self.training_data_buffer, mcts)
+                logger.info('Finishing self-play game...')
             logger.info('Self-play games completed')
 
             logger.info('Training neural network')
@@ -65,10 +69,9 @@ class Trainer:
             self.update_checkpoints(epoch)
         logger.info('Agent training completed')
 
-    def self_play_game(self, training_data_buffer, nnet):
+    def self_play_game(self, training_data_buffer, mcts):
         num_possible_moves = Breakthrough.num_possible_moves()
         game = Breakthrough()
-        mcts = MCTS(nnet)
         states = []
         policies = []
         move_count = 0
@@ -84,6 +87,7 @@ class Trainer:
             
             chosen_move = np.random.choice(num_possible_moves, p=policy)
             game.play_move(chosen_move)
+            mcts.play_move(chosen_move)
             move_count += 1
             
         result = game.get_result()


### PR DESCRIPTION
## Change Log
- Reuse same MCTS instance across self-play games
- Add play_move to MCTS and MCTS retain statistics across moves within a game